### PR TITLE
pass full command line args to skip and delete

### DIFF
--- a/mr
+++ b/mr
@@ -790,10 +790,9 @@ sub action {
 		next if $force && $testname eq "skip";
 
 		my $testcommand=findcommand($testname, $dir, $topdir, $subdir, $is_checkout);
-
 		if (defined $testcommand) {
 			my $ret=runsh "$testname test", $topdir, $subdir,
-				$testcommand, [$action],
+				$testcommand, [$action, @ARGV],
 				sub { system(shift()) };
 			if ($ret != 0) {
 				if (($? & 127) == 2) {


### PR DESCRIPTION
This way, skip can make decisions depending on the command line
arguments.

On particular use case is the following: we can define a git_annex_skip
function that skips a git annex sync <remote> when the remote is not
configured on a particular repo.