### PR TITLE
Fix a couple of issues with how .mrconfig files are loaded.

### DIFF
--- a/mr
+++ b/mr
@@ -1339,8 +1339,14 @@ sub loadconfig {
 		# Add "" as a last resort. It stores config from the DATA section of this file
 		push @parents, "";
 
+		$config{$dir}={};
 		# copy in defaults from first parent
 		foreach my $parent (@parents) {
+			# make sure parent config is loaded
+			if ((! exists $config{$parent}) && -e "$parent/.mrconfig") {
+				loadconfig("$parent/.mrconfig");
+			}
+
 			if (exists $config{$parent} &&
 			    exists $config{$parent}{DEFAULT}) {
 				$config{$dir}{DEFAULT}={ %{$config{$parent}{DEFAULT}} };

--- a/mr
+++ b/mr
@@ -1322,12 +1322,25 @@ sub loadconfig {
 			$configfiles{$dir}=$f;
 		}
 
-		# copy in defaults from first parent
+		# prepare list of parent directories to look for config
+		my @parents;
 		my $parent=$dir;
 		while ($parent=~s/^(.*\/)[^\/]+\/?$/$1/) {
 			if ($parent eq '/') {
 				$parent="";
+				last;
 			}
+			push @parents, "$parent";
+		}
+
+		# Add $HOMEDIR_MR_CONFIG at the end of the lookup path
+		push @parents, abs_path($HOME_MR_CONFIG=~/^(.*\/)[^\/]+$/).'/';
+
+		# Add "" as a last resort. It stores config from the DATA section of this file
+		push @parents, "";
+
+		# copy in defaults from first parent
+		foreach my $parent (@parents) {
 			if (exists $config{$parent} &&
 			    exists $config{$parent}{DEFAULT}) {
 				$config{$dir}{DEFAULT}={ %{$config{$parent}{DEFAULT}} };


### PR DESCRIPTION
There is a full explanation of what is going on in the particular commit messages. To summarize, this two commits do the following:

1. make sure we load DEFAULT from ~/.mrconfig even if a repo is symlinked outside of the home directory.
2. make sure we load DEFAULT from any parent .mrconfig when runing mr in a subdirectory.