### PR TITLE
Fix bootstrap when used with local source file

### DIFF
--- a/mr
+++ b/mr
@@ -1796,12 +1796,14 @@ sub bootstrap {
 	elsif ($src eq '-') {
 		# Config file is read from stdin.
 		copy(\*STDIN, $tmpconfig) || die "stdin: $!";
+		seek $tmpconfig, 0, 0;
 	}
 	else {
 		# Config file is local.
 		die "mr bootstrap: cannot read file '$src'"
 			unless -r $src;
 		copy($src, $tmpconfig) || die "copy: $!";
+		seek $tmpconfig, 0, 0;
 	}
 
 	# Sanity check on destination directory.


### PR DESCRIPTION
Bootstrap from local source files did not work because the file handle position is at the end of the file after the copy operation.
I've added a "seek" operation to move back the file handle position at the start of the file after the copy.