### PR TITLE
Prevent use of pager in `mr status` for git

### DIFF
--- a/mr
+++ b/mr
@@ -2135,7 +2135,7 @@ vcsh_clean =
 	fi
 
 svn_status = svn status "$@"
-git_status = git status -s "$@" || true; git --no-pager log --branches --not --remotes --simplify-by-decoration --decorate --oneline || true; git stash list
+git_status = git status -s "$@" || true; git --no-pager log --branches --not --remotes --simplify-by-decoration --decorate --oneline || true; git --no-pager stash list
 bzr_status = bzr status --short "$@"; bzr missing
 cvs_status = cvs -q status | grep -E '^(File:.*Status:|\?)' | grep -v 'Status: Up-to-date'
 hg_status  = hg status "$@"; hg summary --quiet | grep -v 'parent: 0:'


### PR DESCRIPTION
If a Git repository contains stashes, `mr status` currently stops and waits for user interaction if the pager is enabled in Git configuration (which is the default on many setups). This change disables the pager when calling `git stash list`.